### PR TITLE
fix: CreateParcelItemWeight requires 'values' field, but contains only 'value' field

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -361,7 +361,7 @@ components:
     CreateParcelItemWeight:
       required:
         - accuracy
-        - values
+        - value
       properties:
         accuracy:
           $ref: "#/components/schemas/CreateParcelPropertyAccuracy"


### PR DESCRIPTION
В объекте CreateParcelItemWeight указано обязательное поле 'values', но при этом у него есть только поле 'value'